### PR TITLE
Fixed typo in README

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Usage: wl12xx_build.sh target <
 				wl12xx_modules
 				firmware
 				crda
-				callibrator >  action <download|build|install>
+				calibrator >  action <download|build|install>
 			all
 			clean-all
 


### PR DESCRIPTION
Fixed typo in calibrator target under Usage example.
